### PR TITLE
fix: standardize OpenAI model default to gpt-4o (#50)

### DIFF
--- a/config.py
+++ b/config.py
@@ -95,7 +95,7 @@ class ChirpyConfig:
             max_articles=int(os.getenv("CHIRPY_MAX_ARTICLES", "3")),
             max_summary_length=int(os.getenv("CHIRPY_MAX_SUMMARY_LENGTH", "500")),
             openai_api_key=os.getenv("OPENAI_API_KEY"),
-            openai_model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+            openai_model=os.getenv("OPENAI_MODEL", "gpt-4o"),
             openai_max_tokens=int(os.getenv("OPENAI_MAX_TOKENS", "500")),
             openai_temperature=float(os.getenv("OPENAI_TEMPERATURE", "0.3")),
             tts_engine=os.getenv("TTS_ENGINE", "pyttsx3"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def sample_config(test_db_path):
         max_articles=3,
         max_summary_length=500,
         openai_api_key="test-key",
-        openai_model="gpt-3.5-turbo",
+        openai_model="gpt-4o",
         tts_rate=180,
         tts_volume=0.9,
         log_level="INFO",


### PR DESCRIPTION
## Summary
Fix configuration inconsistency where direct initialization used `gpt-4o` but environment-based initialization used `gpt-3.5-turbo` as default.

## Problem
- **Direct initialization** (`ChirpyConfig()`): Used `gpt-4o` as default (line 29)
- **Environment initialization** (`ChirpyConfig.from_env()`): Used `gpt-3.5-turbo` as default (line 98)
- This caused inconsistent behavior depending on how configuration was created

## Solution
- ✅ Standardize both methods to use `gpt-4o` as default
- ✅ Update test fixture to reflect new standard
- ✅ Maintain backward compatibility via `OPENAI_MODEL` environment variable

## Changes
- `config.py` line 98: `"gpt-3.5-turbo"` → `"gpt-4o"`
- `tests/conftest.py` line 34: Update test fixture to use `gpt-4o`

## Test plan
- [x] All config tests pass (16/16)
- [x] Both initialization methods return same default model
- [x] Quality checks pass (ruff + mypy)
- [x] No breaking changes for existing configurations

## Verification
```python
config1 = ChirpyConfig()              # gpt-4o
config2 = ChirpyConfig.from_env()     # gpt-4o  
# Both now consistent\! ✅
```

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)