### PR TITLE
fix: change default TTS voice from alloy to nova

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,7 +37,7 @@ class ChirpyConfig:
 
     # OpenAI TTS settings
     tts_quality: str = "hd"  # 'basic', 'standard', 'hd'
-    openai_tts_voice: str = "alloy"  # alloy, echo, fable, onyx, nova, shimmer
+    openai_tts_voice: str = "nova"  # alloy, echo, fable, onyx, nova, shimmer
     audio_format: str = "mp3"  # mp3, opus, aac, flac
     tts_speed_multiplier: float = 1.0  # 0.25 to 4.0
 
@@ -102,7 +102,7 @@ class ChirpyConfig:
             tts_rate=int(os.getenv("TTS_RATE", "180")),
             tts_volume=float(os.getenv("TTS_VOLUME", "0.9")),
             tts_quality=os.getenv("TTS_QUALITY", "hd"),
-            openai_tts_voice=os.getenv("OPENAI_TTS_VOICE", "alloy"),
+            openai_tts_voice=os.getenv("OPENAI_TTS_VOICE", "nova"),
             audio_format=os.getenv("AUDIO_FORMAT", "mp3"),
             tts_speed_multiplier=float(os.getenv("TTS_SPEED_MULTIPLIER", "1.0")),
             fetch_timeout=int(os.getenv("FETCH_TIMEOUT", "30")),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -227,7 +227,7 @@ class TestChirpyConfig:
         config = ChirpyConfig()
 
         assert config.tts_quality == "hd"
-        assert config.openai_tts_voice == "alloy"
+        assert config.openai_tts_voice == "nova"
         assert config.audio_format == "mp3"
         assert config.tts_speed_multiplier == 1.0
 


### PR DESCRIPTION
## Summary
- Changes default OpenAI TTS voice from "alloy" to "nova"
- Updates both class attribute default and environment variable fallback

## Changes
- Updated `openai_tts_voice` default in `ChirpyConfig` class from "alloy" to "nova"
- Modified `from_env()` method to use "nova" as default fallback value

## Test plan
- [x] Code quality checks pass
- [x] Type checking passes
- [x] All existing tests continue to pass

Closes #66

🤖 Generated with [Claude Code](https://claude.ai/code)