### PR TITLE
ci: add Dependabot auto-merge for minor/patch

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Dependabot の minor/patch アップデート PR を自動マージするワークフローを追加。

- `dependabot/fetch-metadata@v2` で更新種別を判定
- **minor / patch のみ** auto-merge を有効化（major は手動レビュー）
- マージ方式: **squash**

## Why

これまで Dependabot PR は手動マージしていたが、minor/patch は中身を確認するまでもなく安全な場合が多く、`Require branches to be up to date` 設定下で他PR マージのたびに BEHIND 状態を解消する手間が大きいため。

GitHub の auto-merge 機能を使うので、CI 通過 + base 追従の両方が揃ったタイミングで自動マージされる。

## Notes

- リポジトリ設定で auto-merge は有効化済み
- major バージョンアップは従来通り手動マージのまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)